### PR TITLE
Add print statement to see exact error

### DIFF
--- a/test/feature/steps/compose_util.py
+++ b/test/feature/steps/compose_util.py
@@ -167,6 +167,7 @@ class Composition:
                     raise Exception(_error)
         except:
             err = "Error occurred {0}: {1}".format(cmd, sys.exc_info()[1])
+            print(err)
             output = err
 
         # Don't rebuild if ps command


### PR DESCRIPTION
This adds a print statement to see the exact error when trying to get the list of containers running when performing a `docker-compose up`.

Signed-off-by:
