### PR TITLE
Use items instead of iteritems

### DIFF
--- a/test/feature/steps/compose_util.py
+++ b/test/feature/steps/compose_util.py
@@ -107,7 +107,7 @@ class Composition:
 
     def getEnv(self):
         myEnv = os.environ.copy()
-        for key,value in self.getEnvAdditions().iteritems():
+        for key,value in self.getEnvAdditions().items():
             myEnv[key] = value
         return myEnv
 


### PR DESCRIPTION
Change the code to use items instead of iteritems due to 3.5 not supporting the use of iteritems.

